### PR TITLE
Fix Vite entry HTML and package scripts to render Build Buddy app

### DIFF
--- a/build-buddy-app/index.html
+++ b/build-buddy-app/index.html
@@ -1,1 +1,12 @@
-<div id="root"></div>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Build Buddy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/build-buddy-app/package.json
+++ b/build-buddy-app/package.json
@@ -2,14 +2,16 @@
   "name": "files",
   "version": "1.0.0",
   "description": "An intelligent PC building assistant powered by **Algolia Agent Studio** that helps users create compatible computer builds through proactive compatibility checking and smart recommendations.",
+  "type": "module",
   "main": "compatibility-engine.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "algoliasearch": "^4.25.3",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
### Motivation
- The deployed site showed a blank page because the app HTML did not include the Vite module entry that boots the React app, and the frontend package lacked standard Vite scripts and ESM configuration needed for Vercel builds.

### Description
- Replace the minimal `index.html` with a proper Vite-compatible HTML scaffold and add `<script type="module" src="/src/main.jsx"></script>` so the React entrypoint is loaded. 
- Add `dev`, `build`, and `preview` scripts to `build-buddy-app/package.json` and set the package to ESM via `type: "module"` so Vite runs correctly during local and Vercel builds. 
- Remove the stray duplicate `type` key and cleanup `package.json` to avoid configuration warnings.

### Testing
- Ran `npm --prefix build-buddy-app run dev -- --host 0.0.0.0 --port 4173` and Vite reported the server ready and serving the app URL. 
- Executed a Playwright script that opened `http://127.0.0.1:4173/` and produced a screenshot artifact (`artifacts/build-buddy.png`) confirming the page renders. 
- No automated unit tests are configured for this project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846ce090748322affef192ad50c8f9)