### PR TITLE
Fix Algolia agent endpoint for agent queries

### DIFF
--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -6,7 +6,7 @@ export default function App() {
 
   async function askAgent() {
     const res = await fetch(
-      `https://${import.meta.env.VITE_ALGOLIA_APP_ID}-dsn.algolia.net/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`,
+      `https://agent.algolia.com/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
### Motivation
- The frontend was calling a DSN host path unsupported by Algolia's Agents REST API which returned a 404, so queries must be routed through the correct agent API host.

### Description
- Update the request URL in `build-buddy-app/src/App.jsx` from ``https://${import.meta.env.VITE_ALGOLIA_APP_ID}-dsn.algolia.net/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`` to ``https://agent.algolia.com/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`` to use the supported Algolia Agents REST endpoint.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847094479c832288e19df050a6baa4)