### PR TITLE
Make Agent Studio endpoint configurable via VITE_ALGOLIA_AGENT_BASE_URL

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -35,6 +35,8 @@
   VITE_ALGOLIA_APP_ID=your_app_id
   VITE_ALGOLIA_SEARCH_KEY=your_search_key
   VITE_ALGOLIA_AGENT_ID=your_agent_id
+  # Optional: override Agent Studio endpoint (defaults to https://<APP_ID>.algolia.com)
+  VITE_ALGOLIA_AGENT_BASE_URL=https://your_app_id.algolia.com
   ```
 - [ ] Test locally: `npm run dev`
 - [ ] Verify component selection works
@@ -63,6 +65,7 @@ In Vercel Dashboard → Settings → Environment Variables, add:
 - `VITE_ALGOLIA_APP_ID`
 - `VITE_ALGOLIA_SEARCH_KEY`
 - `VITE_ALGOLIA_AGENT_ID`
+- Optional: `VITE_ALGOLIA_AGENT_BASE_URL`
 
 #### Step 4: Redeploy
 ```bash

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ npm install
 # VITE_ALGOLIA_APP_ID
 # VITE_ALGOLIA_SEARCH_KEY
 # VITE_ALGOLIA_AGENT_ID
+# Optional: override Agent Studio endpoint (defaults to https://<APP_ID>.algolia.com)
+# VITE_ALGOLIA_AGENT_BASE_URL
 
 npm run dev
 ```
@@ -192,6 +194,7 @@ vercel
 # - VITE_ALGOLIA_APP_ID
 # - VITE_ALGOLIA_SEARCH_KEY
 # - VITE_ALGOLIA_AGENT_ID
+# - Optional: VITE_ALGOLIA_AGENT_BASE_URL
 
 # Deploy to production
 vercel --prod

--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -3,10 +3,13 @@ import { useState } from "react";
 export default function App() {
   const [query, setQuery] = useState("");
   const [response, setResponse] = useState("");
+  const agentBaseUrl =
+    import.meta.env.VITE_ALGOLIA_AGENT_BASE_URL ||
+    `https://${import.meta.env.VITE_ALGOLIA_APP_ID}.algolia.com`;
 
   async function askAgent() {
     const res = await fetch(
-      `https://agent.algolia.com/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`,
+      `${agentBaseUrl}/1/agents/${import.meta.env.VITE_ALGOLIA_AGENT_ID}/query`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
### Motivation
- The frontend's hard-coded `https://agent.algolia.com/...` endpoint caused DNS resolution failures in some environments, producing `ERR_NAME_NOT_RESOLVED` when clicking "Ask Agent". 
- Allowing an override for the Agent Studio base URL ensures the app can use the app-specific host (`https://<APP_ID>.algolia.com`) or a custom endpoint when necessary. 

### Description
- Change `build-buddy-app/src/App.jsx` to construct `agentBaseUrl` from `VITE_ALGOLIA_AGENT_BASE_URL` or fall back to ``https://${import.meta.env.VITE_ALGOLIA_APP_ID}.algolia.com`` and use it for the POST to `/1/agents/<AGENT_ID>/query`.
- Document the optional environment variable `VITE_ALGOLIA_AGENT_BASE_URL` in `README.md` and `DEPLOYMENT_CHECKLIST.md` so local and Vercel deployments can set a custom Agent Studio endpoint.
- Commit includes the code and documentation updates and a descriptive commit message. 

### Testing
- Ran `curl -I https://agent.algolia.com/1/agents/<AGENT_ID>/query` which returned a `403` / `CONNECT tunnel failed` indicating the public `agent.algolia.com` path is not reachable from this environment (failed).
- Ran `nslookup agent.algolia.com` and `nslookup agents.algolia.com` which returned `NXDOMAIN` (failed), while `nslookup algolia.com` returned addresses (succeeded).
- Verified the modified files with `nl`/`sed` and committed the changes successfully with `git commit` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984720e8b2c83229ed798dd62da47fd)