### PR TITLE
Pass compatibilityMode as query parameter for agent completions

### DIFF
--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -20,7 +20,9 @@ export default function App() {
     }
 
     try {
-      const res = await fetch(`${agentBaseUrl}/agent-studio/1/agents/${agentId}/completions`, {  // CHANGED: Added agent-studio and changed query to completions
+      const res = await fetch(
+        `${agentBaseUrl}/agent-studio/1/agents/${agentId}/completions?compatibilityMode=legacy`,
+        {  // CHANGED: Added agent-studio and changed query to completions
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -37,8 +39,7 @@ export default function App() {
                 }
               ]
             }
-          ],
-          compatibilityMode: "legacy"
+          ]
         })
       });
 


### PR DESCRIPTION
### Motivation
- The agent API returned a validation error when `compatibilityMode` was missing from the query string, so the client must send it as a query parameter instead of in the request body.
- The change also aligns the client with the correct agent endpoint for completions (`/agent-studio/1/agents/.../completions`).

### Description
- Append `?compatibilityMode=legacy` to the fetch URL used by `askAgent` so the server receives the required query parameter.
- Remove the redundant `compatibilityMode` field from the JSON request body and keep only the `messages` payload sent via `JSON.stringify`.
- Use the completions endpoint path `/agent-studio/1/agents/${agentId}/completions` and ensure request headers include `x-algolia-api-key` and `x-algolia-application-id`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848a886a4c8322b9319ad0681630dd)