### PR TITLE
Switch Algolia agent compatibilityMode to ai-sdk-5

### DIFF
--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -21,7 +21,7 @@ export default function App() {
 
     try {
       const res = await fetch(
-        `${agentBaseUrl}/agent-studio/1/agents/${agentId}/completions?compatibilityMode=legacy`,
+        `${agentBaseUrl}/agent-studio/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`,
         {  // CHANGED: Added agent-studio and changed query to completions
         method: "POST",
         headers: {


### PR DESCRIPTION
### Motivation
- The agent completions endpoint previously used `compatibilityMode=legacy`, which caused validation failures; the parameter needs to be updated to the supported `ai-sdk-5` mode.

### Description
- Updated the completions request URL in `build-buddy-app/src/App.jsx` to use `?compatibilityMode=ai-sdk-5` instead of `legacy`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848b5db2608322a7315f8933ada09a)