### PR TITLE
Improve Build Buddy input for pasted diagnostics

### DIFF
--- a/build-buddy-app/src/App.css
+++ b/build-buddy-app/src/App.css
@@ -1,0 +1,59 @@
+.app {
+  padding: 40px;
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+.input-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.query-input {
+  width: 100%;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #d0d7de;
+  font-size: 14px;
+  resize: vertical;
+  min-height: 140px;
+}
+
+.actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 12px;
+}
+
+button {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: none;
+  background: #1f6feb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #c9d1d9;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: #f6f8fa;
+  color: #24292f;
+  border: 1px solid #d0d7de;
+}
+
+.response {
+  margin-top: 24px;
+  padding: 16px;
+  background: #f6f8fa;
+  border-radius: 12px;
+  border: 1px solid #e6edf3;
+  min-height: 120px;
+  white-space: pre-wrap;
+}

--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import "./App.css";
 
 export default function App() {
   const [query, setQuery] = useState("");
@@ -100,21 +101,41 @@ export default function App() {
   }
 
   return (
-    <div style={{ padding: 40 }}>
+    <div className="app">
       <h1>Build Buddy</h1>
 
-      <input
-        style={{ width: "400px", padding: "8px" }}
+      <label className="input-label" htmlFor="build-query">
+        Describe your PC build or paste diagnostics
+      </label>
+      <textarea
+        id="build-query"
+        className="query-input"
         placeholder="Describe your PC build..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        rows={6}
       />
 
-      <br /><br />
+      <div className="actions">
+        <button onClick={askAgent} disabled={!query.trim()}>
+          Ask Agent
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          onClick={() => {
+            setQuery("");
+            setResponse("");
+          }}
+          disabled={!query && !response}
+        >
+          Clear
+        </button>
+      </div>
 
-      <button onClick={askAgent}>Ask Agent</button>
-
-      <pre>{response}</pre>
+      <pre className="response" aria-live="polite">
+        {response || "Agent responses will appear here."}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the app handle larger pasted diagnostics and multi-line queries more ergonomically by replacing the single-line input with a multi-line editor and clearer UI affordances.

### Description
- Replaced the single-line `<input>` with a labeled `<textarea>` and added an import for the new stylesheet in `build-buddy-app/src/App.jsx`.
- Added a `Clear` action, disabled states for buttons when appropriate, and an accessible response area with `aria-live` for streaming results in `build-buddy-app/src/App.jsx`.
- Added new styles for layout, inputs, buttons, and the response panel in `build-buddy-app/src/App.css`.

### Testing
- Launched the dev server with `npm --prefix build-buddy-app run dev -- --host 0.0.0.0 --port 4173` which started Vite successfully.
- Attempted to capture a UI screenshot with a Playwright script, but the browser launch/crash (`TargetClosedError`) caused the Playwright run to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984909f3aa083229b4544ce13ba3030)