### PR TITLE
Fix lastUrl ReferenceError in agent error handling

### DIFF
--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -15,6 +15,7 @@ export default function App() {
       ]
     : [];
   const configuredAgentBaseUrl = import.meta.env.VITE_ALGOLIA_AGENT_BASE_URL;
+  let lastUrl = "";
 
   const buildAgentUrls = (baseUrls) => {
     const completionsPath = `/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`;
@@ -75,7 +76,6 @@ export default function App() {
         : defaultAgentBaseUrls;
       const candidateUrls = buildAgentUrls(candidateBaseUrls);
       let res = null;
-      let lastUrl = "";
 
       for (const url of candidateUrls) {
         lastUrl = url;


### PR DESCRIPTION
### Motivation
- Prevent `ReferenceError: lastUrl is not defined` when the agent request fails by making the last attempted URL available to the error handler.

### Description
- Declare `let lastUrl = ""` at component scope and remove the duplicate inner declaration inside `askAgent` in `build-buddy-app/src/App.jsx` so the catch block can reference the last attempted URL.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698497b1d410832292008e2dad2868c3)