### PR TITLE
Align Agent Studio completions endpoint, normalize base URLs, and update docs link

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -267,7 +267,7 @@ npm run deploy # (requires gh-pages package)
 - Ask questions in #agent-studio channel
 
 **Algolia Documentation:**
-- Agent Studio: https://www.algolia.com/doc/guides/algolia-ai/agent-studio
+- Agent Studio: http://algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration#api-integration
 - InstantSearch: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js
 
 **DEV Challenge FAQ:** https://dev.to/challenges/algolia-2026-01-07

--- a/build-buddy-app/src/App.jsx
+++ b/build-buddy-app/src/App.jsx
@@ -18,22 +18,16 @@ export default function App() {
   let lastUrl = "";
 
   const buildAgentUrls = (baseUrls) => {
-    const completionsPath = `/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`;
+    const completionsPath = `/agent-studio/1/agents/${agentId}/completions?stream=false&compatibilityMode=ai-sdk-5`;
     const urls = new Set();
 
     baseUrls.forEach((baseUrl) => {
       if (!baseUrl) return;
-      const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+      const normalizedBaseUrl = baseUrl
+        .replace(/\/+$/, "")
+        .replace(/\/agent-studio$/, "");
 
-      if (normalizedBaseUrl.includes("/agent-studio")) {
-        urls.add(`${normalizedBaseUrl}${completionsPath}`);
-        urls.add(
-          `${normalizedBaseUrl.replace(/\/agent-studio$/, "")}${completionsPath}`
-        );
-      } else {
-        urls.add(`${normalizedBaseUrl}/agent-studio${completionsPath}`);
-        urls.add(`${normalizedBaseUrl}${completionsPath}`);
-      }
+      urls.add(`${normalizedBaseUrl}${completionsPath}`);
     });
 
     return Array.from(urls);


### PR DESCRIPTION
### Motivation
- Use the documented Agent Studio HTTP endpoint including `stream=false` and `compatibilityMode=ai-sdk-5` so the app hits the correct API surface.
- Avoid generating duplicate or broken endpoints by normalizing base URLs and removing any existing `/agent-studio` segment before appending the completions path.
- Point the deployment checklist to the specific Algolia Agent Studio API integration documentation.

### Description
- Updated `build-buddy-app/src/App.jsx` `buildAgentUrls` to use `completionsPath = '/agent-studio/1/agents/${agentId}/completions?stream=false&compatibilityMode=ai-sdk-5'` and simplified URL normalization by stripping trailing slashes and any existing `/agent-studio` before composing the final URL.
- Removed the previous branching logic that emitted multiple `/agent-studio` variations and now consistently generates a single normalized endpoint per base URL in `buildAgentUrls`.
- Updated the Agent Studio link in `DEPLOYMENT_CHECKLIST.md` to `http://algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration#api-integration`.

### Testing
- No automated tests were run for these UI/config changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849a939b9c8322889054f754f6fa7b)